### PR TITLE
Alternative implementation to use HAPI FHIR BALP Interceptor ♻️

### DIFF
--- a/server/src/main/java/com/google/fhir/gateway/BalpAuditContextService.java
+++ b/server/src/main/java/com/google/fhir/gateway/BalpAuditContextService.java
@@ -1,0 +1,85 @@
+package com.google.fhir.gateway;
+
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.storage.interceptor.balp.IBalpAuditContextServices;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.annotation.Nonnull;
+import org.apache.http.HttpHeaders;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Reference;
+import org.jetbrains.annotations.NotNull;
+
+public class BalpAuditContextService implements IBalpAuditContextServices {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+  private static final String CLAIM_NAME = "name";
+  private static final String CLAIM_PREFERRED_NAME = "preferred_username";
+  private static final String CLAIM_SUBJECT = "sub";
+
+  @Override
+  public @NotNull Reference getAgentClientWho(RequestDetails requestDetails) {
+
+    return new Reference()
+        // .setReference("Device/fhir-info-gateway")
+        .setType("Device")
+        .setDisplay("FHIR Info Gateway")
+        .setIdentifier(
+            new Identifier()
+                .setSystem("http://fhir-info-gateway/devices")
+                .setValue("fhir-info-gateway-001"));
+  }
+
+  @Override
+  public @NotNull Reference getAgentUserWho(RequestDetails requestDetails) {
+
+    String username = getClaimIfExists(requestDetails, CLAIM_PREFERRED_NAME);
+    String name = getClaimIfExists(requestDetails, CLAIM_NAME);
+    String subject = getClaimIfExists(requestDetails, CLAIM_SUBJECT);
+
+    return new Reference()
+        // .setReference("Practitioner/" + subject)
+        .setType("Practitioner")
+        .setDisplay(name)
+        .setIdentifier(
+            new Identifier()
+                .setSystem("http://fhir-info-gateway/practitioners")
+                .setValue(username));
+  }
+
+  @Override
+  public @NotNull String massageResourceIdForStorage(
+      @Nonnull RequestDetails theRequestDetails,
+      @Nonnull IBaseResource theResource,
+      @Nonnull IIdType theResourceId) {
+
+    /**
+     * Server not configured to allow external references resulting to InvalidRequestException: HTTP
+     * 400 : HAPI-0507: Resource contains external reference to URL. Here we should use relative
+     * references instead e.g. Patient/123;
+     */
+    // String serverBaseUrl = theRequestDetails.getFhirServerBase();
+    return theRequestDetails.getId() != null
+        ? theRequestDetails.getId().getValue()
+        : ""; // For entity POST there will be no agent.who entry reference since not generated yet
+  }
+
+  public String getClaimIfExists(RequestDetails requestDetails, String claimName) {
+    String claim;
+    try {
+      String authHeader = requestDetails.getHeader(HttpHeaders.AUTHORIZATION);
+      String bearerToken = authHeader.substring(BEARER_PREFIX.length());
+      DecodedJWT jwt;
+
+      jwt = JWT.decode(bearerToken);
+      claim = JwtUtil.getClaimOrDie(jwt, claimName);
+    } catch (JWTDecodeException | AuthenticationException e) {
+      claim = "";
+    }
+    return claim;
+  }
+}

--- a/server/src/main/java/com/google/fhir/gateway/BalpAuditEventSink.java
+++ b/server/src/main/java/com/google/fhir/gateway/BalpAuditEventSink.java
@@ -1,0 +1,19 @@
+package com.google.fhir.gateway;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.storage.interceptor.balp.IBalpAuditEventSink;
+import org.hl7.fhir.r4.model.AuditEvent;
+
+public class BalpAuditEventSink implements IBalpAuditEventSink {
+
+  private final IGenericClient genericClient;
+
+  public BalpAuditEventSink(IGenericClient genericClient) {
+    this.genericClient = genericClient;
+  }
+
+  @Override
+  public void recordAuditEvent(AuditEvent auditEvent) {
+    genericClient.create().resource(auditEvent).prettyPrint().encodedJson().execute();
+  }
+}


### PR DESCRIPTION
This implementation of Audit Events integration to the FHIR Info Gateway uses the [BALP interceptor](https://hapifhir.io/hapi-fhir/docs/security/balp_interceptor.html) as documented here https://hapifhir.io/hapi-fhir/docs/interceptors/built_in_server_interceptors.html

Here we register the [BALP Audit Capture interceptor](https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-storage/src/main/java/ca/uhn/fhir/storage/interceptor/balp/BalpAuditCaptureInterceptor.java)  against the gateway's [FhirProxyServer RestfulServer](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/FhirProxyServer.java).

We then invoke the interceptor hooks by programatically triggering the `STORAGE_*` pointcuts _(the same way the HAPI FHIR Server would natively trigger them)_.